### PR TITLE
Issue#21 즐겨찾기 삭제 기능 추가, 조회시 N+1 문제 최적화

### DIFF
--- a/ErrorCode.txt
+++ b/ErrorCode.txt
@@ -41,3 +41,5 @@ ROUTE_001 / 해당 루트를 찾을 수 없습니다. / NOT_FOUND
 
 즐겨찾기
 BOOKMARK_001 / 이미 해당 루트를 즐겨찾기에 등록했습니다. / CONFLICT
+BOOKMARK_002 / 해당 즐겨찾기를 찾을 수 없습니다. / NOT_FOUND
+BOOKMARK_003 / 본인의 즐겨찾기만 삭제할 수 있습니다. / FORBIDDEN

--- a/src/main/java/com/sparta/travelconquestbe/api/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/sparta/travelconquestbe/api/bookmark/controller/BookmarkController.java
@@ -11,7 +11,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,5 +40,11 @@ public class BookmarkController {
       AuthUser authUser) {
     Page<BookmarkListResponse> response = bookmarkService.getBookmarks(authUser, pageable);
     return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteBookmark(@PathVariable Long id, AuthUser authUser) {
+    bookmarkService.deleteBookmark(id, authUser);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/sparta/travelconquestbe/api/bookmark/dto/response/BookmarkListResponse.java
+++ b/src/main/java/com/sparta/travelconquestbe/api/bookmark/dto/response/BookmarkListResponse.java
@@ -1,12 +1,9 @@
 package com.sparta.travelconquestbe.api.bookmark.dto.response;
 
-import com.sparta.travelconquestbe.domain.bookmark.entity.Bookmark;
 import java.time.LocalDateTime;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class BookmarkListResponse {
 
   private Long bookmarkId;
@@ -14,12 +11,11 @@ public class BookmarkListResponse {
   private String routeTitle;
   private LocalDateTime createdAt;
 
-  public static BookmarkListResponse from(Bookmark bookmark) {
-    return BookmarkListResponse.builder()
-        .bookmarkId(bookmark.getId())
-        .routeId(bookmark.getRoute().getId())
-        .routeTitle(bookmark.getRoute().getTitle())
-        .createdAt(bookmark.getCreatedAt())
-        .build();
+  public BookmarkListResponse(Long bookmarkId, Long routeId, String routeTitle,
+      LocalDateTime createdAt) {
+    this.bookmarkId = bookmarkId;
+    this.routeId = routeId;
+    this.routeTitle = routeTitle;
+    this.createdAt = createdAt;
   }
 }

--- a/src/main/java/com/sparta/travelconquestbe/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/sparta/travelconquestbe/domain/bookmark/repository/BookmarkRepository.java
@@ -1,5 +1,6 @@
 package com.sparta.travelconquestbe.domain.bookmark.repository;
 
+import com.sparta.travelconquestbe.api.bookmark.dto.response.BookmarkListResponse;
 import com.sparta.travelconquestbe.domain.bookmark.entity.Bookmark;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
   @Query("SELECT EXISTS (SELECT 1 FROM Bookmark b WHERE b.user.id = :userId AND b.route.id = :routeId)")
   boolean isBookmarkExist(@Param("userId") Long userId, @Param("routeId") Long routeId);
 
-  @Query("SELECT b FROM Bookmark b WHERE b.user.id = :userId ORDER BY b.createdAt DESC")
-  Page<Bookmark> getUserBookmarks(@Param("userId") Long userId, Pageable pageable);
+  @Query("SELECT new com.sparta.travelconquestbe.api.bookmark.dto.response.BookmarkListResponse(" +
+      "b.id, b.route.id, b.route.title, b.createdAt) " +
+      "FROM Bookmark b WHERE b.user.id = :userId ORDER BY b.createdAt DESC")
+  Page<BookmarkListResponse> getUserBookmarks(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/test/java/com/sparta/travelconquestbe/api/bookmark/BookmarkServiceTest.java
+++ b/src/test/java/com/sparta/travelconquestbe/api/bookmark/BookmarkServiceTest.java
@@ -49,7 +49,7 @@ class BookmarkServiceTest {
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
-    authUser = new AuthUser(1L); // Mock User ID
+    authUser = new AuthUser(1L);
     mockRoute = Route.builder().id(1L).title("Test Route").build();
     mockUser = User.builder().id(authUser.getUserId()).build();
   }
@@ -110,14 +110,12 @@ class BookmarkServiceTest {
   @Test
   @DisplayName("즐겨찾기_목록_조회_성공")
   void testGetBookmarks_Success() {
-    Bookmark mockBookmark = Bookmark.builder()
-        .id(1L)
-        .route(mockRoute)
-        .user(mockUser)
-        .build();
+    BookmarkListResponse mockResponse = new BookmarkListResponse(
+        1L, mockRoute.getId(), mockRoute.getTitle(), mockRoute.getCreatedAt()
+    );
 
     PageRequest pageRequest = PageRequest.of(0, 10);
-    Page<Bookmark> mockPage = new PageImpl<>(List.of(mockBookmark), pageRequest, 1);
+    Page<BookmarkListResponse> mockPage = new PageImpl<>(List.of(mockResponse), pageRequest, 1);
 
     when(bookmarkRepository.getUserBookmarks(authUser.getUserId(), pageRequest)).thenReturn(
         mockPage);
@@ -125,8 +123,9 @@ class BookmarkServiceTest {
     Page<BookmarkListResponse> response = bookmarkService.getBookmarks(authUser, pageRequest);
 
     assertThat(response.getContent().size()).isEqualTo(1);
-    assertThat(response.getContent().get(0).getBookmarkId()).isEqualTo(mockBookmark.getId());
-    assertThat(response.getContent().get(0).getRouteId()).isEqualTo(mockRoute.getId());
+    assertThat(response.getContent().get(0).getBookmarkId()).isEqualTo(
+        mockResponse.getBookmarkId());
+    assertThat(response.getContent().get(0).getRouteId()).isEqualTo(mockResponse.getRouteId());
 
     verify(bookmarkRepository, times(1)).getUserBookmarks(authUser.getUserId(), pageRequest);
   }
@@ -135,7 +134,7 @@ class BookmarkServiceTest {
   @DisplayName("즐겨찾기_목록_조회_빈_결과")
   void testGetBookmarks_EmptyResult() {
     PageRequest pageRequest = PageRequest.of(0, 10);
-    Page<Bookmark> mockPage = new PageImpl<>(List.of(), pageRequest, 0);
+    Page<BookmarkListResponse> mockPage = new PageImpl<>(List.of(), pageRequest, 0);
 
     when(bookmarkRepository.getUserBookmarks(authUser.getUserId(), pageRequest)).thenReturn(
         mockPage);
@@ -145,5 +144,56 @@ class BookmarkServiceTest {
     assertThat(response.getContent().size()).isEqualTo(0);
 
     verify(bookmarkRepository, times(1)).getUserBookmarks(authUser.getUserId(), pageRequest);
+  }
+
+  @Test
+  @DisplayName("즐겨찾기_삭제_성공")
+  void testDeleteBookmark_Success() {
+    Bookmark mockBookmark = Bookmark.builder()
+        .id(1L)
+        .user(mockUser)
+        .build();
+
+    when(bookmarkRepository.findById(mockBookmark.getId())).thenReturn(Optional.of(mockBookmark));
+
+    bookmarkService.deleteBookmark(mockBookmark.getId(), authUser);
+
+    verify(bookmarkRepository, times(1)).findById(mockBookmark.getId());
+    verify(bookmarkRepository, times(1)).delete(mockBookmark);
+  }
+
+  @Test
+  @DisplayName("즐겨찾기_삭제_실패_존재하지_않음")
+  void testDeleteBookmark_Fail_NotFound() {
+    when(bookmarkRepository.findById(1L)).thenReturn(Optional.empty());
+
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      bookmarkService.deleteBookmark(1L, authUser);
+    });
+
+    assertThat(exception.getErrorCode()).isEqualTo("BOOKMARK_002");
+    verify(bookmarkRepository, times(1)).findById(1L);
+    verify(bookmarkRepository, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("즐겨찾기_삭제_실패_본인아님")
+  void testDeleteBookmark_Fail_NotOwner() {
+    User anotherUser = User.builder().id(2L).build();
+    Bookmark anotherBookmark = Bookmark.builder()
+        .id(1L)
+        .user(anotherUser)
+        .build();
+
+    when(bookmarkRepository.findById(anotherBookmark.getId())).thenReturn(
+        Optional.of(anotherBookmark));
+
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      bookmarkService.deleteBookmark(anotherBookmark.getId(), authUser);
+    });
+
+    assertThat(exception.getErrorCode()).isEqualTo("BOOKMARK_003");
+    verify(bookmarkRepository, times(1)).findById(anotherBookmark.getId());
+    verify(bookmarkRepository, never()).delete(any());
   }
 }


### PR DESCRIPTION
## 개요

1. 파트

즐겨찾기 삭제 기능 추가
- 즐겨찾기 없으면 예외처리
- 본인의 즐겨찾기만 삭제 가능
- 테스트 코드 추가 

그 외 즐겨찾기 조회시 N+1 문제. 최적화(projection)로 인한 수정

## PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [x]  주석 추가 및 수정
- [x]  문서 수정
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
